### PR TITLE
feat: add actor object type to codebase CLI

### DIFF
--- a/cmd/codebase/internal/create/cmd.go
+++ b/cmd/codebase/internal/create/cmd.go
@@ -25,7 +25,7 @@ func newCreateRootCmd(flagProjectID *string, flagBranch *string, flagFormat *str
 		Use:   "create",
 		Short: "Create a new graph object",
 	}
-	types := []string{"context", "uicomponent", "helper", "action", "apiendpoint", "sourcefile", "domain", "scenario", "step"}
+	types := []string{"context", "uicomponent", "helper", "action", "apiendpoint", "sourcefile", "domain", "scenario", "actor", "step"}
 	for _, t := range types {
 		cmd.AddCommand(newCreateTypeCmd(t, flagProjectID, flagBranch))
 	}
@@ -37,7 +37,7 @@ func newKeyRootCmd() *cobra.Command {
 		Use:   "key",
 		Short: "Generate and print a key for an object type",
 	}
-	types := []string{"context", "uicomponent", "helper", "action", "apiendpoint", "sourcefile", "domain", "scenario", "step"}
+	types := []string{"context", "uicomponent", "helper", "action", "apiendpoint", "sourcefile", "domain", "scenario", "actor", "step"}
 	for _, t := range types {
 		cmd.AddCommand(newKeyTypeCmd(t))
 	}
@@ -112,6 +112,9 @@ func addFlags(cmd *cobra.Command, objType string, opts *cbcreate.CreateOptions) 
 		cmd.Flags().StringVar(&opts.Given, "given", "", "Given")
 		cmd.Flags().StringVar(&opts.When, "when", "", "When")
 		cmd.Flags().StringVar(&opts.Then, "then", "", "Then")
+	case "actor":
+		cmd.Flags().StringVar(&opts.ActorRole, "role", "", "Actor role (human/ai/system)")
+		cmd.Flags().StringVar(&opts.ActorType, "type", "", "Actor type (e.g. end-user, assistant, platform)")
 	case "step":
 		cmd.Flags().IntVar(&opts.Order, "order", 0, "Order (required for key)")
 		cmd.Flags().StringVar(&opts.Scenario, "scenario", "", "Scenario key (required for key)")

--- a/cmd/codebase/internal/create/keys.go
+++ b/cmd/codebase/internal/create/keys.go
@@ -73,6 +73,11 @@ func ScenarioKey(name string) string {
 	return "scn-" + slugify(name)
 }
 
+// Actor: act-<name-slug>
+func ActorKey(name string) string {
+	return "act-" + slugify(name)
+}
+
 // ScenarioStep: step-<scn-abbrev-3tokens>-<N>
 func ScenarioStepKey(scenarioKey string, order int) string {
 	// scn-create-meeting -> step-create-meeting-1

--- a/pkg/codebase/commands/create/cmd.go
+++ b/pkg/codebase/commands/create/cmd.go
@@ -38,6 +38,9 @@ type CreateOptions struct {
 	Given string
 	When  string
 	Then  string
+	// Actor
+	ActorRole string
+	ActorType string
 	// Step
 	Order    int
 	Scenario string
@@ -73,6 +76,8 @@ func GenerateKey(objType, name string, opts *CreateOptions) string {
 		return DomainKey(s)
 	case "scenario":
 		return ScenarioKey(name)
+	case "actor":
+		return ActorKey(name)
 	case "step":
 		return ScenarioStepKey(opts.Scenario, opts.Order)
 	default:
@@ -145,6 +150,8 @@ func mapType(objType string) string {
 		return "Domain"
 	case "scenario":
 		return "Scenario"
+	case "actor":
+		return "Actor"
 	case "step":
 		return "ScenarioStep"
 	default:
@@ -198,6 +205,9 @@ func buildProps(objType, name string, opts *CreateOptions) map[string]any {
 		p["given"] = opts.Given
 		p["when"] = opts.When
 		p["then"] = opts.Then
+	case "actor":
+		p["role"] = opts.ActorRole
+		p["type"] = opts.ActorType
 	case "step":
 		p["order"] = opts.Order
 	}

--- a/pkg/codebase/commands/create/keys.go
+++ b/pkg/codebase/commands/create/keys.go
@@ -61,6 +61,10 @@ func DomainKey(slug string) string {
 	return "dom-" + Slugify(slug)
 }
 
+func ActorKey(name string) string {
+	return "act-" + Slugify(name)
+}
+
 func ScenarioKey(name string) string {
 	return "scn-" + Slugify(name)
 }


### PR DESCRIPTION
## Problem

The Memory Platform's `Actor` graph type existed in `FallbackTypes` and the schema, but the `codebase` CLI had no support for creating or generating keys for Actor objects. Users had to fall back to `codebase graph create --type Actor --key act-... --properties '...'` instead of using the native `codebase create actor` command.

## Changes

### `pkg/codebase/commands/create/keys.go`
- Add `ActorKey(name string) string` → generates `act-<name-slug>` keys

### `pkg/codebase/commands/create/cmd.go`
- Add `"actor"` case to `GenerateKey()` → calls `ActorKey(name)`
- Add `"actor"` case to `mapType()` → returns `"Actor"`
- Add `ActorRole` and `ActorType` fields to `CreateOptions` struct
- Add `"actor"` case to `buildProps()` → sets `role` and `type` properties

### `cmd/codebase/internal/create/keys.go`
- Add `ActorKey(name string) string` → generates `act-<name-slug>` keys

### `cmd/codebase/internal/create/cmd.go`
- Add `"actor"` to the types list in `newCreateRootCmd()`
- Add `"actor"` to the types list in `newKeyRootCmd()`
- Add `--role` flag (human/ai/system) and `--type` flag (end-user/assistant/platform) for actor creation

## Verification

```bash
# Key generation
$ codebase key actor diane
act-diane

# Actor creation
$ codebase create actor diane --role ai --type assistant --description "AI assistant" --upsert
act-diane
```

## Related
- Closes #2
