### PR TITLE
fix: api_key support, graph relate key resolution, --format json support

### DIFF
--- a/cmd/codebase/internal/config/config.go
+++ b/cmd/codebase/internal/config/config.go
@@ -83,6 +83,7 @@ type CodebaseYML struct {
 	Project   string     `yaml:"project"`    // project name (resolved to ID via API)
 	ProjectID string     `yaml:"project_id"` // explicit project ID (skips name lookup)
 	Server    string     `yaml:"server"`     // optional server URL override
+	APIKey    string     `yaml:"api_key"`    // optional API key (falls back to env, ~/.memory/config.yaml)
 	Sync      SyncConfig `yaml:"sync"`       // sync sub-command configuration
 }
 
@@ -96,16 +97,19 @@ type Client struct {
 
 // New creates a configured Client. flagProjectID overrides all other sources.
 func New(flagProjectID, flagBranch string) (*Client, error) {
+	yml, err := findAndParseYML()
+	if err == nil {
+		if yml.APIKey != "" {
+			os.Setenv("MEMORY_API_KEY", yml.APIKey)
+		}
+		if yml.Server != "" {
+			os.Setenv("MEMORY_SERVER_URL", yml.Server)
+		}
+	}
+
 	sdkClient, err := sdk.NewFromEnv()
 	if err != nil {
-		yml, _ := findAndParseYML()
-		if yml != nil && yml.Server != "" {
-			os.Setenv("MEMORY_SERVER_URL", yml.Server)
-			sdkClient, err = sdk.NewFromEnv()
-		}
-		if err != nil {
-			return nil, fmt.Errorf("memory auth: %w", err)
-		}
+		return nil, fmt.Errorf("memory auth: %w", err)
 	}
 
 	projectID := flagProjectID

--- a/cmd/codebase/internal/graph/cmd.go
+++ b/cmd/codebase/internal/graph/cmd.go
@@ -52,6 +52,7 @@ func NewCmd(flagProjectID *string, flagBranch *string, flagFormat *string) *cobr
 				return err
 			}
 			adapter := NewSDKAdapter(c.Graph)
+			useJSON := flagListJSON || *flagFormat == "json"
 			return cbgraph.List(context.Background(), adapter, cmd.OutOrStdout(), cbgraph.ListOptions{
 				Type:    flagType,
 				Key:     flagKey,
@@ -61,7 +62,7 @@ func NewCmd(flagProjectID *string, flagBranch *string, flagFormat *string) *cobr
 				Filter:  flagFilter,
 				Status:  flagStatus,
 				Count:   flagCount,
-				JSON:    flagListJSON,
+				JSON:    useJSON,
 				Verbose: flagVerbose,
 			})
 		},
@@ -113,13 +114,14 @@ func NewCmd(flagProjectID *string, flagBranch *string, flagFormat *string) *cobr
 				return err
 			}
 			adapter := NewSDKAdapter(c.Graph)
+			useJSON := flagCreateJSON || *flagFormat == "json"
 			return cbgraph.Create(context.Background(), adapter, cmd.OutOrStdout(), cbgraph.CreateOptions{
 				Type:       flagType,
 				Key:        flagKey,
 				Properties: flagProperties,
 				Status:     flagStatus,
 				Upsert:     flagUpsert,
-				JSON:       flagCreateJSON,
+				JSON:       useJSON,
 			})
 		},
 	}

--- a/pkg/codebase/commands/graph/crud.go
+++ b/pkg/codebase/commands/graph/crud.go
@@ -294,10 +294,23 @@ type RelateOptions struct {
 }
 
 func Relate(ctx context.Context, gc cbgraph.GraphClient, w io.Writer, opts RelateOptions) error {
+	srcID := opts.From
+	if !uuidRE.MatchString(opts.From) {
+		if o, err := cbgraph.GetByKey(ctx, gc, opts.From); err == nil {
+			srcID = o.EntityID
+		}
+	}
+	dstID := opts.To
+	if !uuidRE.MatchString(opts.To) {
+		if o, err := cbgraph.GetByKey(ctx, gc, opts.To); err == nil {
+			dstID = o.EntityID
+		}
+	}
+
 	req := &sdkgraph.CreateRelationshipRequest{
 		Type:  opts.Type,
-		SrcID: opts.From,
-		DstID: opts.To,
+		SrcID: srcID,
+		DstID: dstID,
 	}
 
 	var rel *sdkgraph.GraphRelationship

--- a/pkg/codebase/config/config.go
+++ b/pkg/codebase/config/config.go
@@ -48,5 +48,6 @@ type CodebaseYML struct {
 	Project   string     `yaml:"project"`
 	ProjectID string     `yaml:"project_id"`
 	Server    string     `yaml:"server"`
+	APIKey    string     `yaml:"api_key"`
 	Sync      SyncConfig `yaml:"sync"`
 }


### PR DESCRIPTION

## Changes

### Issue #9: .codebase.yml silently ignores api_key field
- Added `APIKey` field to `CodebaseYML` in both `pkg/codebase/config/` and `cmd/codebase/internal/config/`
- `config.New()` now passes YAML's `api_key` as `MEMORY_API_KEY` env var before SDK init
- Fixes the confusing silent-ignore that forced users to debug auth issues

### Issue #7: graph relate --type returns 'invalid request body'
- Added object key → entity ID resolution in `Relate()` before creating relationships
- When `--from`/`--to` are object keys (e.g. `act-user`) instead of UUIDs, the function looks up entity IDs first
- Pattern already proven in `CreateBatch()` — this just extends it to the direct `graph relate` command

### Issue #8: graph list --format json outputs table, not JSON
- Made `graph list` and `graph create` respect the global `--format json` flag in addition to their own `--json` flags
- Users can now use either `--json` or `--format json` for JSON output

### Issue #14: analyze scenarios [0 steps]
- Root cause: relationships couldn't be created via the CLI (blocked by #7)
- The analyze scenarios code correctly fetches and displays `has_step` relationships
- Fixing #7 unblocks the primary workflow

## Testing
- `go build ./...` for all 3 modules ✓
- `go vet ./...` for all 3 modules ✓

Closes #9
Closes #7
Closes #8
Addresses #14
